### PR TITLE
Use execFileSync instead of execSync when calling sleep.

### DIFF
--- a/source/lambda/msk-lambda-kdf/index.js
+++ b/source/lambda/msk-lambda-kdf/index.js
@@ -20,7 +20,7 @@ const FIREHOSE_MAX_SIZE_BYTES = 4194304;
 const FIREHOSE_RETRIES = 3;
 
 // OS command does not accept any user input.
-exports.sleep = (seconds) => child_process.execSync(`sleep ${seconds}`); // NOSONAR (javascript:S4721)
+exports.sleep = (seconds) => child_process.execFileSync('sleep', [seconds]); // NOSONAR (javascript:S4721)
 
 const _putRecords = async (records) => {
     const options = JSON.parse(process.env.AWS_SDK_USER_AGENT);


### PR DESCRIPTION
Description of changes:

In `sleep`, use `execFileSync` to call the OS `sleep` command instead of `execSync`.

This is slightly tidier and prevents command injection in case a client passes in untrusted input.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
